### PR TITLE
Add converting functions to/from Java UUID

### DIFF
--- a/core/api/kotlinx-uuid-core.api
+++ b/core/api/kotlinx-uuid-core.api
@@ -7,6 +7,11 @@ public final class kotlinx/uuid/BinarySerializer : kotlinx/serialization/KSerial
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/uuid/UUID;)V
 }
 
+public final class kotlinx/uuid/ConvertingKt {
+	public static final fun toJavaUUID (Lkotlinx/uuid/UUID;)Ljava/util/UUID;
+	public static final fun toKotlinUUID (Ljava/util/UUID;)Lkotlinx/uuid/UUID;
+}
+
 public abstract interface annotation class kotlinx/uuid/InternalAPI : java/lang/annotation/Annotation {
 }
 

--- a/core/src/jvmMain/kotlin/kotlinx/uuid/Converting.kt
+++ b/core/src/jvmMain/kotlin/kotlinx/uuid/Converting.kt
@@ -4,5 +4,14 @@
 
 package kotlinx.uuid
 
+/**
+ * Converts this [java.util.UUID][java.util.UUID] value to a [kotlinx.uuid.UUID][UUID] value
+ * by using the default [toString] representation.
+ */
 public fun java.util.UUID.toKotlinUUID(): UUID = UUID(toString())
+
+/**
+ * Converts this [kotlinx.uuid.UUID][UUID] value to a [java.util.UUID][java.util.UUID] value
+ * by using the default [toString] representation.
+ */
 public fun UUID.toJavaUUID(): java.util.UUID = java.util.UUID.fromString(toString())

--- a/core/src/jvmMain/kotlin/kotlinx/uuid/Converting.kt
+++ b/core/src/jvmMain/kotlin/kotlinx/uuid/Converting.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid
+
+public fun java.util.UUID.toKotlinUUID(): UUID = UUID(toString())
+public fun UUID.toJavaUUID(): java.util.UUID = java.util.UUID.fromString(toString())

--- a/core/src/jvmTest/kotlin/kotlinx/uuid/tests/JavaConvertingTest.kt
+++ b/core/src/jvmTest/kotlin/kotlinx/uuid/tests/JavaConvertingTest.kt
@@ -5,7 +5,6 @@
 package kotlinx.uuid.tests
 
 import kotlinx.uuid.*
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/core/src/jvmTest/kotlin/kotlinx/uuid/tests/JavaConvertingTest.kt
+++ b/core/src/jvmTest/kotlin/kotlinx/uuid/tests/JavaConvertingTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid.tests
+
+import kotlinx.uuid.*
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JavaConvertingTest {
+
+    @Test
+    fun toJavaUUID() {
+        val kotlinUUID = UUID(SOME_UUID_STRING)
+        val javaUUID = kotlinUUID.toJavaUUID()
+        assertEquals(SOME_UUID_STRING, javaUUID.toString())
+    }
+
+    @Test
+    fun fromJavaUUID() {
+        val javaUUID = java.util.UUID.fromString(SOME_UUID_STRING)
+        val kotlinUUID = javaUUID.toKotlinUUID()
+        assertEquals(SOME_UUID_STRING, kotlinUUID.toString())
+    }
+}


### PR DESCRIPTION
To use existing Java libraries, eg a ORM framework, you still need to use `java.util.UUID`.