### PR TITLE
Add NSUUID Converter for iOS Support

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -12,9 +12,7 @@ val kotlinxSerializationVersion: String by project.extra
 kotlin {
     jvm()
     macosX64()
-    iosArm32()
-    iosArm64()
-    iosX64()
+    ios()
     linuxX64()
     linuxArm64()
     js(BOTH) {

--- a/core/src/iosMain/kotlin/kotlinx/uuid/Converter.kt
+++ b/core/src/iosMain/kotlin/kotlinx/uuid/Converter.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid
+
+/**
+ * Converts this [platform.Foundation.NSUUID][platform.Foundation.NSUUID] value to a [kotlinx.uuid.UUID][UUID] value
+ * by using the [UUIDString][platform.Foundation.NSUUID.UUIDString] representation.
+ */
+public fun platform.Foundation.NSUUID.toKotlinUUID(): UUID = UUID(UUIDString)
+
+/**
+ * Converts this [kotlinx.uuid.UUID][UUID] value to a [platform.Foundation.NSUUID][platform.Foundation.NSUUID] value
+ * by using the default [toString] representation.
+ */
+public fun UUID.toNsUUID(): platform.Foundation.NSUUID = platform.Foundation.NSUUID(toString())

--- a/core/src/iosTest/kotlin/kotlinx/uuid/NsUUIDConvertingTest.kt
+++ b/core/src/iosTest/kotlin/kotlinx/uuid/NsUUIDConvertingTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid
+
+import kotlinx.uuid.tests.SOME_UUID_STRING
+import kotlin.test.*
+
+class NsUUIDConvertingTest {
+
+    @Test
+    fun toNsUUID() {
+        val kotlinUUID = UUID(SOME_UUID_STRING)
+        val nsUUID = kotlinUUID.toNsUUID()
+        assertEquals(SOME_UUID_STRING, nsUUID.UUIDString.toLowerCase())
+    }
+
+    @Test
+    fun fromNsUUID() {
+        val nsUUID = platform.Foundation.NSUUID(SOME_UUID_STRING)
+        val kotlinUUID = nsUUID.toKotlinUUID()
+        assertEquals(SOME_UUID_STRING, kotlinUUID.toString())
+    }
+}

--- a/core/src/iosTest/kotlin/kotlinx/uuid/NsUUIDConvertingTest.kt
+++ b/core/src/iosTest/kotlin/kotlinx/uuid/NsUUIDConvertingTest.kt
@@ -8,7 +8,7 @@
 
 package kotlinx.uuid
 
-import kotlinx.uuid.tests.SOME_UUID_STRING
+import kotlinx.uuid.tests.*
 import kotlin.test.*
 
 class NsUUIDConvertingTest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.parallel=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.incremental.js=true
 kotlin.incremental.multiplatform=true
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false


### PR DESCRIPTION
If wanted, these changes add builtin support to convert a Kotlin UUID to a Foundation NSUUID/Swift UUID.

The implementation uses the `iOSMain` sourceSet by using `iOS()` in build.gradle.kts, **which removes iOS 32Bit support!** Since iOS 11, released 2017-09-19, iOS is 64Bit only.