### PR TITLE
Add Exposed DAO Support

### DIFF
--- a/exposed/api/exposed-uuid.api
+++ b/exposed/api/exposed-uuid.api
@@ -4,6 +4,15 @@ public final class kotlinx/uuid/exposed/DslKt {
 	public static final fun kotlinxUUID (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 }
 
+public abstract class kotlinx/uuid/exposed/KotlinxUUIDEntity : org/jetbrains/exposed/dao/Entity {
+	public fun <init> (Lorg/jetbrains/exposed/dao/id/EntityID;)V
+}
+
+public abstract class kotlinx/uuid/exposed/KotlinxUUIDEntityClass : org/jetbrains/exposed/dao/EntityClass {
+	public fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public class kotlinx/uuid/exposed/KotlinxUUIDTable : org/jetbrains/exposed/dao/id/IdTable {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/random/Random;)V

--- a/exposed/build.gradle.kts
+++ b/exposed/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
             dependencies {
                 api(project(":kotlinx-uuid-core"))
                 api("org.jetbrains.exposed:exposed-core:$exposedVersion")
+                api("org.jetbrains.exposed:exposed-dao:$exposedVersion")
             }
         }
         getByName("jvmTest") {

--- a/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDEntity.kt
+++ b/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDEntity.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid.exposed
+
+import kotlinx.uuid.*
+import org.jetbrains.exposed.dao.*
+import org.jetbrains.exposed.dao.id.EntityID
+
+/**
+ * A [UUID](Kotlinx.uuid.UUID) DAO Entity for using the Exposed DAO API.
+ */
+public abstract class KotlinxUUIDEntity(id: EntityID<UUID>) : Entity<UUID>(id)

--- a/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDEntityClass.kt
+++ b/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDEntityClass.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid.exposed
+
+import kotlinx.uuid.*
+import org.jetbrains.exposed.dao.*
+import org.jetbrains.exposed.dao.id.*
+
+/**
+ * A [UUID](Kotlinx.uuid.UUID) DAO EntityClass for using the Exposed DAO API.
+ */
+public abstract class KotlinxUUIDEntityClass<out E : KotlinxUUIDEntity>(
+    table: IdTable<UUID>,
+    entityType: Class<E>? = null
+) : EntityClass<UUID, E>(table, entityType)

--- a/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDTable.kt
+++ b/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDTable.kt
@@ -4,13 +4,11 @@
 
 package kotlinx.uuid.exposed
 
-import kotlinx.uuid.UUID
-import kotlinx.uuid.generateUUID
-import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
-import org.jetbrains.exposed.sql.Column
-import java.security.SecureRandom
-import kotlin.random.asKotlinRandom
+import kotlinx.uuid.*
+import org.jetbrains.exposed.dao.id.*
+import org.jetbrains.exposed.sql.*
+import java.security.*
+import kotlin.random.*
 
 /**
  * Identity table with a key column having type [UUID]. Unique identifiers are generated before

--- a/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDTable.kt
+++ b/exposed/src/jvmMain/kotlin/kotlinx/uuid/exposed/KotlinxUUIDTable.kt
@@ -4,14 +4,16 @@
 
 package kotlinx.uuid.exposed
 
-import kotlinx.uuid.*
-import org.jetbrains.exposed.dao.id.*
-import org.jetbrains.exposed.sql.*
-import java.security.*
-import kotlin.random.*
+import kotlinx.uuid.UUID
+import kotlinx.uuid.generateUUID
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
+import java.security.SecureRandom
+import kotlin.random.asKotlinRandom
 
 /**
- * Identity table with a key column having type [UUID]. Unique identifiers are genreated before
+ * Identity table with a key column having type [UUID]. Unique identifiers are generated before
  * insertion by [UUID.Companion.generateUUID] with [SecureRandom] by default.
  *
  * @param name of the table.

--- a/exposed/src/jvmTest/kotlin/kotlinx/uuid/exposed/tests/UUIDDaoTests.kt
+++ b/exposed/src/jvmTest/kotlin/kotlinx/uuid/exposed/tests/UUIDDaoTests.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2020 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.uuid.exposed.tests
+
+import kotlinx.uuid.*
+import kotlinx.uuid.exposed.*
+import org.jetbrains.exposed.dao.id.*
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.*
+import kotlin.test.*
+
+class UUIDDaoTests {
+
+    @Test
+    fun smokeTestWithH2() {
+        val db = Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
+        transaction(db) {
+            SchemaUtils.create(TestTables)
+            assertTrue(UUIDTableTest.TestTable.exists())
+            assertTrue(TestTable.all().toList().isEmpty())
+            val newId = TestTable.new { }.id.value
+            assertNotNull(newId)
+            assertEquals(newId, TestTable[newId].id.value)
+        }
+    }
+
+    object TestTables : KotlinxUUIDTable()
+
+    class TestTable(id: EntityID<UUID>) : KotlinxUUIDEntity(id) {
+        companion object : KotlinxUUIDEntityClass<TestTable>(TestTables)
+    }
+}

--- a/exposed/src/jvmTest/kotlin/kotlinx/uuid/exposed/tests/UUIDDaoTests.kt
+++ b/exposed/src/jvmTest/kotlin/kotlinx/uuid/exposed/tests/UUIDDaoTests.kt
@@ -18,7 +18,7 @@ class UUIDDaoTests {
         val db = Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
         transaction(db) {
             SchemaUtils.create(TestTables)
-            assertTrue(UUIDTableTest.TestTable.exists())
+            assertTrue(TestTables.exists())
             assertTrue(TestTable.all().toList().isEmpty())
             val newId = TestTable.new { }.id.value
             assertNotNull(newId)


### PR DESCRIPTION
You can use Exposed with SQL DSL and DAO api. This PR adds the latter.