### PR TITLE
Update Gradle Build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -55,7 +55,6 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.12")
             }
         }
         val jsTest by getting {

--- a/exposed/build.gradle.kts
+++ b/exposed/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
         getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.12")
 
                 implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
                 implementation("com.h2database:h2:1.4.200")

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,3 @@ kotlin.incremental.js=true
 kotlin.incremental.multiplatform=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-
-# bintray doesn't recognize sha512
-systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gson/build.gradle.kts
+++ b/gson/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.12")
             }
         }
     }

--- a/jackson/build.gradle.kts
+++ b/jackson/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.12")
                 implementation(kotlin("reflect"))
                 implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
             }

--- a/ktor/server/build.gradle.kts
+++ b/ktor/server/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.12")
                 implementation("io.ktor:ktor-server-test-host:$ktorVersion")
             }
         }


### PR DESCRIPTION
- Add Gradle Dependabot: It finally supports Gradle kts files.
- Add Checksums for Publishing, according to https://github.com/gradle/gradle/issues/11412 Bintray now supports checksums.
- Remove explicit dependency on JUnit, kotlin-test-junit has already a dependency to it.
